### PR TITLE
python-paho-mqtt: remove dependency already included in python3-light

### DIFF
--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -25,7 +25,7 @@ define Package/python3-paho-mqtt
   SUBMENU:=Python
   TITLE:=MQTT version 5.0/3.1.1 client class
   URL:=http://eclipse.org/paho
-  DEPENDS:=+python3-light +python3-uuid
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-paho-mqtt/description


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
